### PR TITLE
Refactor `Client` fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = "0.11.22"

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[allow(unused)]
 enum EventType {
     All,
     Operation,
@@ -19,25 +20,82 @@ enum EventType {
     Lifecycle,
 }
 
+#[allow(unused)]
 struct Cert {
     cert: String,
     key: String,
 }
 
-struct Client {
-    endpoint: String,
-    version: String,
-    verify: bool, // Could also potentially be a string - need to figure out how to do that
-    timeout: f32, // Could also be a tuple.
-    project: String,
-    session: Session, // Should be a custom data type possibly
+#[allow(unused)]
+enum Endpoint {
+    Http(String),
+    UnixSocket(String),
 }
 
-type Session = (); // TODO: implement me!
+#[allow(unused)]
+enum LxdAPIVersion {
+    V1_0,
+    // TODO: complete me!
+}
+
+#[allow(unused)]
+struct Timeouts {
+    server_timeout_seconds: u32,
+    connection_timeout_seconds: u32,
+}
+
+impl Timeouts {
+    #[allow(unused)]
+    pub fn new(server_timeout_seconds: u32, connection_timeout_seconds: u32) -> Self {
+        Self {
+            server_timeout_seconds,
+            connection_timeout_seconds,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn from_seconds(timeout: u32) -> Self {
+        Self::new(timeout, timeout)
+    }
+}
+
+struct ClientConfig {
+    pub endpoint: Endpoint, // address to lxd server e.g. http:./// or unix socket
+    pub version: LxdAPIVersion,
+    pub verify: bool, // Could also potentially be a string - need to figure out how to do that
+    pub timeout_seconds: Option<Timeouts>, // Could also be a tuple.
+    pub project: Option<String>,
+}
+
+struct Client {
+    #[allow(unused)]
+    endpoint: Endpoint, // address to lxd server e.g. http:./// or unix socket
+    #[allow(unused)]
+    version: LxdAPIVersion,
+    #[allow(unused)]
+    verify: bool, // Could also potentially be a string - need to figure out how to do that
+    #[allow(unused)]
+    timeout_seconds: Option<Timeouts>, // Could also be a tuple.
+    #[allow(unused)]
+    project: String,
+}
 
 impl Client {
+    #[allow(unused)]
     pub fn connect(&mut self) {
         // TODO: Connect to the LXD REST API.
         //  Try to just pull up some basic info after connecting to the REST API.
+    }
+}
+
+impl From<ClientConfig> for Client {
+    fn from(cfg: ClientConfig) -> Self {
+        Self {
+            endpoint: cfg.endpoint,
+            version: cfg.version,
+            verify: cfg.verify,
+            timeout_seconds: cfg.timeout_seconds,
+            project: cfg.project.unwrap_or("default".into()),
+        }
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -15,6 +15,7 @@
 //! Interact with LXD instances.
 
 // I have no idea if half of these should be strings but oh well
+#[allow(unused)]
 pub struct Instance {
     name: String, // TODO: Ensure that this is read-only
     description: String,


### PR DESCRIPTION
This PR improves the types used in `Client` and fixes a few warnings.

Just for the record of our discussions, we're currently looking to implement an API which looks something like this---
```rust
fn main() -> Result<(), Box<dyn Error>> {
    let client = Client::from(ClientConfig {
        // ...
    });
    let instance = client.instances().get("container-name");
    // NB: instances can only be created via a client; they may implement serde's Serialize but certainly NOT Deserialize.
    client.add_instance(...);
    client.remove_instance(instance);
    instance.rename();
    println!("{}", instance);

    for instance in client.instances() {
        println!("{}", instance.name())
    }

    Ok(())
}
```
