### PR TITLE
Add makefile for local testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+# NOTE: keep these in sync with Makefile targets,
+# so developers can run ci-equivalent tests locally.
 jobs:
   build:
     name: Build nlxd

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: test lint fmt check-fmt build release
+
+export RUSTFLAGS = --deny warnings
+
+# the test target should be kept in sync with the CI,
+# so running this target should be equivalent to running in CI.
+test: lint check-fmt
+	cargo test --all-features
+
+lint:
+	cargo clippy --all-features
+
+check-fmt:
+	cargo fmt --check
+
+fmt:
+	cargo fmt
+
+build:
+	cargo build
+
+release:
+	cargo build --release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# nlxd
+
+## Developing
+
+Install prerequisites:
+
+- a recent rust toolchain with cargo
+- rustfmt
+- cargo clippy
+
+Check your changes before pushing:
+
+```
+make test
+```
+
+(The CI runs the equivalent of `make test`.)


### PR DESCRIPTION
We need to be able to run ci-equivalent commands locally, so we can iterate quickly in development.

This adds a makefile and some docs.

It would be nice if we could use make commands directly in the CI, instead of relying on the github-specific actions. But this is next best thing if we're stuck with that for now. :)
