### PR TITLE
Fill out all fields for the Instance type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ isahc = {version = "1.7.2", features = ["default", "json"]}
 thiserror = "1.0.49"
 serde = {version = "1.0.188", features = ["derive"]}
 serde_json = "1.0.107"
+serde_repr = "0.1.18"
+chrono = {version = "0.4.34", features = ["serde"]}

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,6 +98,7 @@ enum ResponseType {
     Error,
 }
 
+// TODO: turn this into an enum based on the three standard return types: https://documentation.ubuntu.com/lxd/en/latest/rest-api/#return-values
 #[derive(Debug, Deserialize)]
 struct Response<T> {
     metadata: T,
@@ -107,7 +108,7 @@ struct Response<T> {
     #[serde(rename = "type")]
     response_type: ResponseType,
     #[allow(unused)]
-    // TODO: enum based on https://documentation.ubuntu.com/lxd/en/latest/rest-api/#list-of-current-status-codes
+    // TODO: enum for http codes - use serde_repr
     status_code: u32,
 }
 
@@ -193,12 +194,14 @@ impl Client {
         Ok(response.json()?)
     }
 
+    /// Get a list of instance names
     pub fn instances(&self) -> Result<Vec<String>> {
         Ok(self
             .get(&format!("{}/instances", self.version.to_url_segment()))?
             .metadata)
     }
 
+    /// Get an instance's by instance name.
     pub fn get_instance(&self, name: &str) -> Result<Instance> {
         Ok(self.get(name)?.metadata)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,14 +194,14 @@ impl Client {
         Ok(response.json()?)
     }
 
-    /// Get a list of instance names
+    /// Get a list of instance names.
     pub fn instances(&self) -> Result<Vec<String>> {
         Ok(self
             .get(&format!("{}/instances", self.version.to_url_segment()))?
             .metadata)
     }
 
-    /// Get an instance's by instance name.
+    /// Try to get an instance by its name.
     pub fn get_instance(&self, name: &str) -> Result<Instance> {
         Ok(self.get(name)?.metadata)
     }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -16,7 +16,9 @@
 
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use serde_repr::Deserialize_repr;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -40,21 +42,59 @@ pub enum Device {
     },
 }
 
-// TODO: deny unknown fields once Instance type is complete
-// #[serde(deny_unknown_fields)]
+#[derive(Debug, Deserialize)]
+pub enum InstanceStatus {
+    Running,
+    Stopped,
+    Frozen,
+    Error,
+}
+
+/// Status code from the REST API.
+/// This is not for HTTP status codes.
+/// Codes documented at https://documentation.ubuntu.com/lxd/en/latest/rest-api/#status-codes
+#[derive(Debug, Deserialize_repr)]
+#[repr(u16)]
+pub enum StatusCode {
+    OperationCreated = 100,
+    Started = 101,
+    Stopped = 102,
+    Running = 103,
+    Canceling = 104,
+    Pending = 105,
+    Starting = 106,
+    Stopping = 107,
+    Aborting = 108,
+    Freezing = 109,
+    Frozen = 110,
+    Thawed = 111,
+    Error = 112,
+    Ready = 113,
+    Success = 200,
+    Failure = 400,
+    Canceled = 401,
+}
+
 #[allow(unused)]
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Instance {
+    architecture: String,
+    config: HashMap<String, String>, // TODO: is config completely described - can we use a struct?
+    created_at: DateTime<Utc>,
+    description: String,
+    devices: HashMap<String, Device>,
+    ephemeral: bool,
+    expanded_config: HashMap<String, String>,
+    expanded_devices: HashMap<String, Device>,
+    last_used_at: DateTime<Utc>,
+    location: String,
     name: String,
+    profiles: Vec<String>,
     project: String,
     stateful: bool,
-    status: String,   // TODO: could be an enum
-    status_code: u32, // TODO: maybe also an enum?
-    location: String,
-    profiles: Vec<String>,
+    status: InstanceStatus, // TODO: not sure if this string is consistent (could have i18n?)
+    status_code: StatusCode,
     #[serde(rename = "type")]
     instance_type: InstanceType,
-    last_used_at: String, // TODO: datetime type
-    expanded_devices: HashMap<String, Device>,
-    // TODO: the remaining fields
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -42,20 +42,11 @@ pub enum Device {
     },
 }
 
-#[derive(Debug, Deserialize)]
-pub enum InstanceStatus {
-    Running,
-    Stopped,
-    Frozen,
-    Error,
-}
-
-/// Status code from the REST API.
-/// This is not for HTTP status codes.
+/// Code from the REST API for instance status.
 /// Codes documented at https://documentation.ubuntu.com/lxd/en/latest/rest-api/#status-codes
 #[derive(Debug, Deserialize_repr)]
 #[repr(u16)]
-pub enum StatusCode {
+pub enum InstanceStatus {
     OperationCreated = 100,
     Started = 101,
     Stopped = 102,
@@ -77,10 +68,10 @@ pub enum StatusCode {
 
 #[allow(unused)]
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Instance {
     architecture: String,
-    config: HashMap<String, String>, // TODO: is config completely described - can we use a struct?
+    // TODO: determine if config is completely described.  If so, we can potentially use a struct.
+    config: HashMap<String, String>,
     created_at: DateTime<Utc>,
     description: String,
     devices: HashMap<String, Device>,
@@ -93,8 +84,8 @@ pub struct Instance {
     profiles: Vec<String>,
     project: String,
     stateful: bool,
-    status: InstanceStatus, // TODO: not sure if this string is consistent (could have i18n?)
-    status_code: StatusCode,
+    #[serde(rename = "status_code")]
+    status: InstanceStatus,
     #[serde(rename = "type")]
     instance_type: InstanceType,
 }


### PR DESCRIPTION
This should completely cover the fields described in the api documentation for [GET /1.0/instances](https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).

Note that `restore` is documented there, but does not appear in actual responses (and shouldn't appear; this appears to be a docs issue).  I opened https://github.com/canonical/lxd/issues/12993 to report it.

Fixes #9 